### PR TITLE
- [电波提醒] 修复无链接通知点击提示地址不合法的问题

### DIFF
--- a/src/screens/_/item/notify/index.tsx
+++ b/src/screens/_/item/notify/index.tsx
@@ -73,7 +73,7 @@ export const ItemNotify = observer(
 
     return (
       <Component id='item-notify' data-key={href}>
-        {connectUserId ? (
+        {connectUserId || !href ? (
           elBody
         ) : (
           <Link


### PR DESCRIPTION
当普通电波提醒项未解析到 href 时，直接渲染静态内容，不再包裹 Link。

这可以避免“通过了你的好友请求”等纯文本提醒点击后继续触发 appNavigate/open('')，
从而出现“地址不合法”的提示。