### PR TITLE
- [空间] 修复高级用户标签在部分入口不显示的问题

### DIFF
--- a/src/screens/user/zone/store/computed.ts
+++ b/src/screens/user/zone/store/computed.ts
@@ -210,13 +210,17 @@ export default class Computed extends State {
   }
 
   @computed get isAdvance() {
-    return systemStore.isAdvance(this.usersInfo.id, this.userId)
+    return systemStore.isAdvance(this.usersInfo.id || this.userId, this.username)
   }
 
   @computed get advanceDetail() {
     if (!userStore.isDeveloper) return ''
 
-    return systemStore.advanceDetail[this.usersInfo.id] || systemStore.advanceDetail[this.userId]
+    return (
+      systemStore.advanceDetail[this.usersInfo.id] ||
+      systemStore.advanceDetail[this.userId] ||
+      systemStore.advanceDetail[this.username]
+    )
   }
 
   @computed get currentChatValues() {

--- a/src/screens/user/zone/store/computed.ts
+++ b/src/screens/user/zone/store/computed.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2024-04-08 12:49:58
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-05-11 07:42:45
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 02:56:51
  */
 import { computed } from 'mobx'
 import { fixedHD, getCDNAvatar } from '@components/avatar/utils'
@@ -210,13 +210,13 @@ export default class Computed extends State {
   }
 
   @computed get isAdvance() {
-    return systemStore.isAdvance(this.userId, this.username)
+    return systemStore.isAdvance(this.usersInfo.id, this.userId)
   }
 
   @computed get advanceDetail() {
     if (!userStore.isDeveloper) return ''
 
-    return systemStore.advanceDetail[this.userId || this.username]
+    return systemStore.advanceDetail[this.usersInfo.id] || systemStore.advanceDetail[this.userId]
   }
 
   @computed get currentChatValues() {

--- a/src/stores/system/computed.ts
+++ b/src/stores/system/computed.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2023-04-23 15:11:13
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-04-22 22:44:49
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 02:50:10
  */
 import { computed } from 'mobx'
 import { radiusMd } from '@styles'
@@ -127,7 +127,7 @@ export default class Computed extends State implements StoreConstructor<typeof S
   }
 
   /** 是否高级用户 */
-  isAdvance(userId: UserId, userName?: string) {
+  isAdvance(userId: number, userName?: UserId) {
     return computed<boolean>(() => {
       let flag = false
       if (userId) flag = userId in this.advanceDetail

--- a/src/stores/system/computed.ts
+++ b/src/stores/system/computed.ts
@@ -127,7 +127,7 @@ export default class Computed extends State implements StoreConstructor<typeof S
   }
 
   /** 是否高级用户 */
-  isAdvance(userId: number, userName?: UserId) {
+  isAdvance(userId: UserId, userName?: UserId) {
     return computed<boolean>(() => {
       let flag = false
       if (userId) flag = userId in this.advanceDetail


### PR DESCRIPTION
经查看 advance.json，发现里面多数是数字 ID 少数是用户名，但 isAdvance 只检查用户名与昵称，改了用户名但 advance.json 里还是数字 ID 的用户空间无法正常显示高级用户标签。因此修改为向 isAdvance 传入数字 ID 与用户名。

advanceDetail 预期效果应该是 userId 查不到回退到 username，但现行逻辑只要有 userId 就不会检查 username，已在修改传入参数的基础上修改响应逻辑。