### PR TITLE
- [时间胶囊] 修复安卓底部回弹导致滑动触控异常的问题

### DIFF
--- a/src/components/list-view/list/index.tsx
+++ b/src/components/list-view/list/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2021-11-30 04:24:34
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-03-19 01:45:11
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 07:08:42
  */
 import React from 'react'
 import { FlatList, SectionList } from 'react-native'
@@ -24,8 +24,8 @@ function List<ItemT>({
   const passProps: any = {
     ref: connectRef,
     removeClippedSubviews: true,
-    ...other,
     overScrollMode: 'always',
+    ...other,
     alwaysBounceHorizontal: false,
     alwaysBounceVertical: false,
     legacyImplementation: false

--- a/src/screens/timeline/v2/component/list/index.tsx
+++ b/src/screens/timeline/v2/component/list/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2019-04-14 00:51:13
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-05-07 20:12:36
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 07:08:28
  */
 import React, { useCallback, useMemo } from 'react'
 import { observer } from 'mobx-react'
@@ -82,6 +82,7 @@ function List({ title }: Props) {
       data={timeline}
       renderItem={handleRenderItem}
       scrollEventThrottle={16}
+      overScrollMode='never'
       onScroll={handleScroll}
       onHeaderRefresh={$.onHeaderRefresh}
       onFooterRefresh={$.fetchTimeline}


### PR DESCRIPTION
注意到问题并未解决，且用户空间时间线同样没有 Android overscroll，
因此允许 ListView 覆盖 overScrollMode，并在时间胶囊列表中禁用 Android overscroll，
避免触底加载期间继续滑动时进入 stretch / rebound 状态。

Refs: #324