### PR TITLE
- [帖子] 修复回复框未解码 HTML 实体的问题

### DIFF
--- a/src/screens/rakuen/topic/store/action.ts
+++ b/src/screens/rakuen/topic/store/action.ts
@@ -8,10 +8,10 @@ import { toJS } from 'mobx'
 import { HEADER_TRANSITION_HEIGHT } from '@components/header/utils'
 import { rakuenStore, systemStore, uiStore } from '@stores'
 import {
+  decodeHTMLEntities,
   feedback,
   getRandomItems,
   getTimestamp,
-  HTMLDecode,
   info,
   loading,
   removeHTMLTag,
@@ -141,7 +141,7 @@ export default class Action extends Fetch {
     let placeholder = ''
     if (username) placeholder = `回复 ${username}：`
     if (msg) {
-      let comment = HTMLDecode(removeHTMLTag(msg, false))
+      let comment = decodeHTMLEntities(removeHTMLTag(msg, false))
       if (comment.length >= 64) comment = `${comment.slice(0, 64)}...`
       placeholder += comment
     }

--- a/src/utils/html/index.ts
+++ b/src/utils/html/index.ts
@@ -31,11 +31,33 @@ const DECODE_SPECIAL_CHARS = {
   '&quot;': '"'
 } as const
 
+/** 解码十进制或十六进制数字 HTML 实体（如 emoji） */
+export function decodeNumericHTMLEntity(match: string, value: string, radix: number): string {
+  const codePoint = Number.parseInt(value, radix)
+
+  if (!Number.isFinite(codePoint)) return match
+
+  try {
+    return String.fromCodePoint(codePoint)
+  } catch {
+    return match
+  }
+}
+
 /** HTML 反转义 */
 export function HTMLDecode(str: string = ''): string {
   if (str.length === 0) return ''
 
-  return str.replace(/(&amp;|&lt;|&gt;|&nbsp;|&#39;|&quot;)/g, match => DECODE_SPECIAL_CHARS[match])
+  return str
+    .replace(/(&amp;|&lt;|&gt;|&nbsp;|&#39;|&quot;)/g, match => {
+      return DECODE_SPECIAL_CHARS[match] || match
+    })
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => {
+      return decodeNumericHTMLEntity(match, hex, 16)
+    })
+    .replace(/&#(\d+);/g, (match, dec) => {
+      return decodeNumericHTMLEntity(match, dec, 10)
+    })
 }
 
 const ENCODE_SPECIAL_CHARS = {

--- a/src/utils/html/index.ts
+++ b/src/utils/html/index.ts
@@ -44,8 +44,8 @@ export function decodeNumericHTMLEntity(match: string, value: string, radix: num
   }
 }
 
-/** HTML 反转义 */
-export function HTMLDecode(str: string = ''): string {
+/** 含十进制或十六进制数字 HTML 实体（如 emoji）的 HTML 反转义 */
+export function decodeHTMLEntities(str: string = ''): string {
   if (str.length === 0) return ''
 
   return str
@@ -58,6 +58,13 @@ export function HTMLDecode(str: string = ''): string {
     .replace(/&#(\d+);/g, (match, dec) => {
       return decodeNumericHTMLEntity(match, dec, 10)
     })
+}
+
+/** HTML 反转义 */
+export function HTMLDecode(str: string = ''): string {
+  if (str.length === 0) return ''
+
+  return str.replace(/(&amp;|&lt;|&gt;|&nbsp;|&#39;|&quot;)/g, match => DECODE_SPECIAL_CHARS[match])
 }
 
 const ENCODE_SPECIAL_CHARS = {


### PR DESCRIPTION
通过扩展 HTML 实体解码逻辑，支持十进制和十六进制数字实体的方式，修复了超展开回复框 placeholder 中数字 HTML 实体未解码的问题。