### PR TITLE
- [贴贴] 取消表情列表展开按钮，统一为横向滑动显示全部

### DIFF
--- a/src/screens/_/base/likes/ds.ts
+++ b/src/screens/_/base/likes/ds.ts
@@ -1,16 +1,15 @@
 /*
  * @Author: czy0729
  * @Date: 2023-04-01 06:09:02
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-04-23 20:49:52
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 20:21:58
  */
-import { _ } from '@stores'
 import { rc } from '@utils/dev'
 import { COMPONENT as PARENT } from '../ds'
 
 export const COMPONENT = rc(PARENT, 'Likes')
 
-export const LIMIT = _.device(3, 5)
+export const LIMIT = 12
 
 export const HIT_SLOP = {
   top: 12,

--- a/src/screens/_/base/likes/index.tsx
+++ b/src/screens/_/base/likes/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2023-03-31 05:22:23
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-04-23 22:13:49
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 11:19:05
  */
 import React from 'react'
 import { toJS } from 'mobx'
@@ -11,11 +11,10 @@ import { Component, Flex, Iconfont, ScrollView, Touchable } from '@components'
 import { rakuenStore, timelineStore, uiStore } from '@stores'
 import { feedback } from '@utils'
 import { r } from '@utils/dev'
-import { useBoolean } from '@utils/hooks'
 import { IOS, LIKE_TYPE_SAY, LIKE_TYPE_TIMELINE } from '@constants'
 import Btn from './btn'
 import Flip from './flip'
-import { COMPONENT, HIT_SLOP, LIMIT } from './ds'
+import { COMPONENT, HIT_SLOP } from './ds'
 import { memoStyles } from './styles'
 
 import type { Props as LikesProps } from './types'
@@ -32,14 +31,11 @@ export const Likes = observer(
     formhash,
     likeType,
     offsets,
-    limit = LIMIT,
     storybook,
     onPress,
     onLongPress
   }: LikesProps) => {
     r(COMPONENT)
-
-    const { state, setTrue } = useBoolean(show)
 
     if (!rakuenStore.setting.likes) return null
 
@@ -82,31 +78,22 @@ export const Likes = observer(
               </Flex>
             </Touchable>
           )}
-          {likesList
-            .filter((item, index) => (item.selected ? true : state ? true : index < limit))
-            .map(item => {
-              const passProps = {
-                topicId,
-                id,
-                formhash,
-                selected: false,
-                onPress,
-                onLongPress,
-                ...item
-              }
-              return (
-                <Flip key={item.emoji} height={28} {...passProps}>
-                  <Btn {...passProps} />
-                </Flip>
-              )
-            })}
-          {likesList.length >= limit + 1 && !state && (
-            <Touchable animate hitSlop={HIT_SLOP} onPress={setTrue}>
-              <Flex style={styles.item} justify='center'>
-                <Iconfont name='md-navigate-next' size={18} />
-              </Flex>
-            </Touchable>
-          )}
+          {likesList.map(item => {
+            const passProps = {
+              topicId,
+              id,
+              formhash,
+              selected: false,
+              onPress,
+              onLongPress,
+              ...item
+            }
+            return (
+              <Flip key={item.emoji} height={28} {...passProps}>
+                <Btn {...passProps} />
+              </Flip>
+            )
+          })}
         </ScrollView>
       </Component>
     )

--- a/src/screens/_/base/likes/index.tsx
+++ b/src/screens/_/base/likes/index.tsx
@@ -2,7 +2,7 @@
  * @Author: czy0729
  * @Date: 2023-03-31 05:22:23
  * @Last Modified by: imagebuilder1837
- * @Last Modified time: 2026-05-22 11:19:05
+ * @Last Modified time: 2026-05-22 20:15:51
  */
 import React from 'react'
 import { toJS } from 'mobx'
@@ -11,10 +11,11 @@ import { Component, Flex, Iconfont, ScrollView, Touchable } from '@components'
 import { rakuenStore, timelineStore, uiStore } from '@stores'
 import { feedback } from '@utils'
 import { r } from '@utils/dev'
+import { useBoolean } from '@utils/hooks'
 import { IOS, LIKE_TYPE_SAY, LIKE_TYPE_TIMELINE } from '@constants'
 import Btn from './btn'
 import Flip from './flip'
-import { COMPONENT, HIT_SLOP } from './ds'
+import { COMPONENT, HIT_SLOP, LIMIT } from './ds'
 import { memoStyles } from './styles'
 
 import type { Props as LikesProps } from './types'
@@ -31,11 +32,14 @@ export const Likes = observer(
     formhash,
     likeType,
     offsets,
+    limit = LIMIT,
     storybook,
     onPress,
     onLongPress
   }: LikesProps) => {
     r(COMPONENT)
+
+    const { state, setTrue } = useBoolean(show)
 
     if (!rakuenStore.setting.likes) return null
 
@@ -53,6 +57,11 @@ export const Likes = observer(
     const showCreateBtn = show || showCreate
     if (!showCreateBtn && !likesList.length) return null
 
+    const visibleLikesList = likesList.filter(
+      (item, index) => item.selected || state || index < limit
+    )
+    const hasHiddenLikes =
+      !state && likesList.some((item, index) => !item.selected && index >= limit)
     const styles = memoStyles()
 
     return (
@@ -78,7 +87,7 @@ export const Likes = observer(
               </Flex>
             </Touchable>
           )}
-          {likesList.map(item => {
+          {visibleLikesList.map(item => {
             const passProps = {
               topicId,
               id,
@@ -94,6 +103,13 @@ export const Likes = observer(
               </Flip>
             )
           })}
+          {hasHiddenLikes && (
+            <Touchable animate hitSlop={HIT_SLOP} onPress={setTrue}>
+              <Flex style={styles.item} justify='center'>
+                <Iconfont name='md-navigate-next' size={18} />
+              </Flex>
+            </Touchable>
+          )}
         </ScrollView>
       </Component>
     )

--- a/src/screens/_/base/likes/types.ts
+++ b/src/screens/_/base/likes/types.ts
@@ -2,7 +2,7 @@
  * @Author: czy0729
  * @Date: 2023-04-05 14:59:57
  * @Last Modified by: imagebuilder1837
- * @Last Modified time: 2026-05-22 11:19:21
+ * @Last Modified time: 2026-05-22 20:24:34
  */
 import type { rakuenStore } from '@stores'
 import type { BlogId, Fn, Id, SubjectId, TopicId, ViewStyle } from '@types'
@@ -29,6 +29,9 @@ export type Props = {
 
   /** 贴贴类型 */
   likeType: Id
+
+  /** 默认显示贴贴数量 */
+  limit?: number
 
   /** 偏移值 */
   offsets?: {

--- a/src/screens/_/base/likes/types.ts
+++ b/src/screens/_/base/likes/types.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2023-04-05 14:59:57
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-04-23 22:12:27
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 11:19:21
  */
 import type { rakuenStore } from '@stores'
 import type { BlogId, Fn, Id, SubjectId, TopicId, ViewStyle } from '@types'
@@ -29,9 +29,6 @@ export type Props = {
 
   /** 贴贴类型 */
   likeType: Id
-
-  /** 默认显示贴贴数量 */
-  limit?: number
 
   /** 偏移值 */
   offsets?: {

--- a/src/screens/_/item/collections/item.tsx
+++ b/src/screens/_/item/collections/item.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2022-06-17 12:19:32
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-05-09 00:36:29
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 11:18:48
  */
 import React, { useCallback, useMemo } from 'react'
 import { View } from 'react-native'
@@ -105,12 +105,7 @@ const Item = memo(
             numberOfLines={commentsLines}
           />
         )}
-        <Likes
-          relatedId={relatedId}
-          subjectId={id}
-          limit={(commentsFull ? 5 : 3) + _.device(0, 3)}
-          showCreate={showLikesCreate}
-        />
+        <Likes relatedId={relatedId} subjectId={id} showCreate={showLikesCreate} />
       </>
     )
 

--- a/src/screens/_/item/collections/likes/index.tsx
+++ b/src/screens/_/item/collections/likes/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: czy0729
  * @Date: 2024-03-24 08:40:54
- * @Last Modified by: czy0729
- * @Last Modified time: 2026-04-23 22:14:05
+ * @Last Modified by: imagebuilder1837
+ * @Last Modified time: 2026-05-22 11:18:30
  */
 import React from 'react'
 import { observer } from 'mobx-react'
@@ -10,7 +10,7 @@ import { uiStore, userStore } from '@stores'
 import { LIKE_TYPE_TIMELINE } from '@constants'
 import { Likes as LikesComp } from '../../../base'
 
-function Likes({ relatedId, subjectId, limit, showCreate }) {
+function Likes({ relatedId, subjectId, showCreate }) {
   if (!relatedId) return null
 
   return (
@@ -18,7 +18,6 @@ function Likes({ relatedId, subjectId, limit, showCreate }) {
       topicId={subjectId}
       id={relatedId}
       likeType={LIKE_TYPE_TIMELINE}
-      limit={limit}
       showCreate={showCreate}
       formhash={userStore.formhash}
       onLongPress={uiStore.showLikesUsers}


### PR DESCRIPTION
- 取消 Likes 列表超过 limit 后显示的展开按钮
- 贴贴表情统一直接渲染到横向 ScrollView 中
- 时光机、条目详情页与时间胶囊页保持一致：超出屏幕后手动横向滑动查看更多

Refs #328