### PR TITLE
- [空间] 收藏页支持切换条目类型

### DIFF
--- a/src/constants/events/user.ts
+++ b/src/constants/events/user.ts
@@ -57,6 +57,7 @@ export default {
   '空间.历史': 'Zone.used',
   '空间.绝交': 'Zone.blockUser',
   '空间.聊天': 'Zone.chat',
+  '空间.收藏类型切换': 'Zone.switchCollectionType',
 
   时间线: 'UserTimeline',
   '时间线.跳转': 'UserTimeline.to',

--- a/src/screens/user/zone/component/bangumi-list/index.tsx
+++ b/src/screens/user/zone/component/bangumi-list/index.tsx
@@ -53,7 +53,7 @@ function BangumiList({ ListHeaderComponent, onScroll }: Props) {
 
       $.forwardRef(
         ref,
-        TABS.findIndex(item => item.title === '番剧')
+        TABS.findIndex(item => item.title === '收藏')
       )
     },
     [$]

--- a/src/screens/user/zone/component/bangumi-list/item/index.tsx
+++ b/src/screens/user/zone/component/bangumi-list/item/index.tsx
@@ -15,10 +15,10 @@ import { EVENT } from './ds'
 import type { Ctx } from '../../../types'
 import type { Props } from './types'
 
-function Item({ item, title }: Props) {
+function Item({ item, status }: Props) {
   const { $ } = useStore<Ctx>()
 
-  if (!$.state.expand[title]) return null
+  if (!$.state.expand[status]) return null
 
   return (
     <Flex wrap='wrap' align='start'>
@@ -33,7 +33,7 @@ function Item({ item, title }: Props) {
             event={EVENT}
           />
         ))}
-      {title.includes('在看') && <Heatmap id='空间.跳转' to='Subject' alias='条目' />}
+      {status === '在看' && <Heatmap id='空间.跳转' to='Subject' alias='条目' />}
     </Flex>
   )
 }

--- a/src/screens/user/zone/component/bangumi-list/item/types.ts
+++ b/src/screens/user/zone/component/bangumi-list/item/types.ts
@@ -9,5 +9,5 @@ import type { CollectionStatusCn } from '@types'
 
 export type Props = {
   item: CollectionsItem
-  title: CollectionStatusCn
+  status: CollectionStatusCn
 }

--- a/src/screens/user/zone/component/bangumi-list/section-header/index.tsx
+++ b/src/screens/user/zone/component/bangumi-list/section-header/index.tsx
@@ -14,16 +14,16 @@ import { memoStyles } from './styles'
 
 import type { Ctx } from '../../../types'
 
-function SectionHeader({ title, count }) {
+function SectionHeader({ title, status, count }) {
   const { $ } = useStore<Ctx>()
 
   const handlePress = useCallback(() => {
-    $.onToggleSection(title)
-  }, [$, title])
+    $.onToggleSection(status)
+  }, [$, status])
 
   const styles = memoStyles()
 
-  const expand = $.state.expand[title]
+  const expand = $.state.expand[status]
   const elRight = useMemo(
     () => (
       <Iconfont
@@ -36,14 +36,14 @@ function SectionHeader({ title, count }) {
   )
 
   return (
-    <Touchable style={stl(styles.section, title === '在看' && _.mt.sm)} onPress={handlePress}>
+    <Touchable style={stl(styles.section, status === '在看' && _.mt.sm)} onPress={handlePress}>
       <SectionHeaderComp style={styles.sectionHeader} type='title' size={15} right={elRight}>
         {title}{' '}
         <Text type='sub' size={13} bold lineHeight={15}>
           {count}
         </Text>
       </SectionHeaderComp>
-      {title === '在看' && <Heatmap id='空间.展开分组' />}
+      {status === '在看' && <Heatmap id='空间.展开分组' />}
     </Touchable>
   )
 }

--- a/src/screens/user/zone/component/bangumi-list/utils.tsx
+++ b/src/screens/user/zone/component/bangumi-list/utils.tsx
@@ -9,15 +9,27 @@ import Item from './item'
 import SectionHeader from './section-header'
 
 import type { CollectionsItem } from '@stores/user/types'
-import type { CollectionStatusCn, RenderSection } from '@types'
+import type { CollectionStatusCn } from '@types'
 
-export function renderSectionHeader({ section: { title, count } }) {
-  return <SectionHeader title={title} count={count} />
+type Section = {
+  section: {
+    title: string
+    status: CollectionStatusCn
+    count: number
+  }
+}
+
+type ItemSection = Section & {
+  item: CollectionsItem
+}
+
+export function renderSectionHeader({ section: { title, status, count } }: Section) {
+  return <SectionHeader title={title} status={status} count={count} />
 }
 
 export function renderItem({
   item,
-  section: { title }
-}: RenderSection<CollectionStatusCn, CollectionsItem>) {
-  return <Item item={item} title={title} />
+  section: { status }
+}: ItemSection) {
+  return <Item item={item} status={status} />
 }

--- a/src/screens/user/zone/component/rakuen-list/index.tsx
+++ b/src/screens/user/zone/component/rakuen-list/index.tsx
@@ -52,7 +52,7 @@ function RakuenList({ ListHeaderComponent, onScroll }: Props) {
 
       $.forwardRef(
         ref,
-        TABS.findIndex(item => item.title === '番剧')
+        TABS.findIndex(item => item.title === '超展开')
       )
     },
     [$]

--- a/src/screens/user/zone/component/tab-bar-label/ds.ts
+++ b/src/screens/user/zone/component/tab-bar-label/ds.ts
@@ -10,4 +10,6 @@ import { COMPONENT as PARENT } from '../ds'
 
 export const COMPONENT = rc(PARENT, 'TabBarLabel')
 
+export const COLLECTION_PAGE = TABS.findIndex(item => item.title === '收藏')
+
 export const TIMELINE_PAGE = TABS.findIndex(item => item.title === '时间线')

--- a/src/screens/user/zone/component/tab-bar-label/index.tsx
+++ b/src/screens/user/zone/component/tab-bar-label/index.tsx
@@ -10,7 +10,8 @@ import { Flex, Text } from '@components'
 import { Popover } from '@_'
 import { _, useStore } from '@stores'
 import { MODEL_TIMELINE_TYPE, TIMELINE_TYPE } from '@constants'
-import { COMPONENT, TIMELINE_PAGE } from './ds'
+import { COLLECTION_TYPES } from '../../ds'
+import { COLLECTION_PAGE, COMPONENT, TIMELINE_PAGE } from './ds'
 import { styles } from './styles'
 
 import type { Ctx } from '../../types'
@@ -37,6 +38,24 @@ function TabBarLabel({ style, title }: Props) {
           <Text size={10} lineHeight={13} type='sub' noWrap>
             {' '}
             {MODEL_TIMELINE_TYPE.getLabel($.state.timelineType)}{' '}
+          </Text>
+        </Flex>
+      </Popover>
+    )
+  }
+
+  if (title === '收藏' && $.state.page === COLLECTION_PAGE) {
+    return (
+      <Popover
+        style={_.container.block}
+        data={COLLECTION_TYPES.map(item => item.title)}
+        onSelect={$.onSelectCollectionType}
+      >
+        <Flex style={styles.popover} justify='center'>
+          {elText}
+          <Text size={10} lineHeight={13} type='sub' noWrap>
+            {' '}
+            {$.collectionTypeLabel}{' '}
           </Text>
         </Flex>
       </Popover>

--- a/src/screens/user/zone/ds.ts
+++ b/src/screens/user/zone/ds.ts
@@ -4,6 +4,10 @@
  * @Last Modified by: czy0729
  * @Last Modified time: 2026-03-14 16:44:31
  */
+import { MODEL_SUBJECT_TYPE } from '@constants'
+
+import type { SubjectType } from '@types'
+
 export { H_HEADER, H_RADIUS_LINE, H_TABBAR } from '@screens/user/v2/ds'
 
 export const COMPONENT = 'Zone'
@@ -14,7 +18,7 @@ export const TABS = [
     key: 'about'
   },
   {
-    title: '番剧',
+    title: '收藏',
     key: 'bangumi'
   },
   {
@@ -28,6 +32,29 @@ export const TABS = [
   {
     title: '超展开',
     key: 'rakuen'
+  }
+] as const
+
+export const COLLECTION_TYPES = [
+  {
+    title: '动画',
+    value: MODEL_SUBJECT_TYPE.getLabel<SubjectType>('动画')
+  },
+  {
+    title: '书籍',
+    value: MODEL_SUBJECT_TYPE.getLabel<SubjectType>('书籍')
+  },
+  {
+    title: '音乐',
+    value: MODEL_SUBJECT_TYPE.getLabel<SubjectType>('音乐')
+  },
+  {
+    title: '游戏',
+    value: MODEL_SUBJECT_TYPE.getLabel<SubjectType>('游戏')
+  },
+  {
+    title: '三次元',
+    value: MODEL_SUBJECT_TYPE.getLabel<SubjectType>('三次元')
   }
 ] as const
 

--- a/src/screens/user/zone/store/action.ts
+++ b/src/screens/user/zone/store/action.ts
@@ -11,14 +11,18 @@ import { fetchHTML, t } from '@utils/fetch'
 import { completions, get, update } from '@utils/kv'
 import { MUSUME_PROMPT, MUSUME_ZONE_PROMPT } from '@utils/kv/ds'
 import { webhookFriend } from '@utils/webhooks'
-import { HOST, MODEL_TIMELINE_SCOPE, MODEL_TIMELINE_TYPE } from '@constants'
+import { HOST, MODEL_SUBJECT_TYPE, MODEL_TIMELINE_SCOPE, MODEL_TIMELINE_TYPE } from '@constants'
 import Fetch from './fetch'
+import { DEFAULT_COLLECTION_EXPAND } from './ds'
 
 import type { ScrollTo, ScrollToOffset } from '@components'
 import type {
   CompletionItem,
+  CollectionStatusCn,
   Navigation,
   ScrollEvent,
+  SubjectType,
+  SubjectTypeCn,
   TimeLineScope,
   TimeLineType,
   TimeLineTypeCn
@@ -108,7 +112,7 @@ export default class Action extends Fetch {
   /** 标签页切换后回调, 延迟请求对应页面数据 */
   onTabChangeCallback = async (page: number) => {
     const { title } = this.tabs[page]
-    if (title === '番剧') {
+    if (title === '收藏') {
       await this.fetchUserCollections()
     } else if (title === '时间线') {
       await this.fetchUsersTimeline(true)
@@ -123,13 +127,13 @@ export default class Action extends Fetch {
     setTimeout(() => this.updatePageOffset([0]), 0)
   }
 
-  /** 番剧展开分组 */
-  onToggleSection = (title: string) => {
+  /** 收藏展开分组 */
+  onToggleSection = (status: CollectionStatusCn) => {
     const { expand } = this.state
     t('空间.展开分组', {
       userId: this.userId,
-      title,
-      expand: !expand[title]
+      title: status,
+      expand: !expand[status]
     })
 
     if (systemStore.setting.zoneCollapse) {
@@ -140,7 +144,7 @@ export default class Action extends Fetch {
           想看: false,
           搁置: false,
           抛弃: false,
-          [title]: !expand[title]
+          [status]: !expand[status]
         }
       })
       return
@@ -149,10 +153,29 @@ export default class Action extends Fetch {
     this.setState({
       expand: {
         ...expand,
-        [title]: !expand[title]
+        [status]: !expand[status]
       }
     })
     this.save()
+  }
+
+  /** 选择收藏类型 */
+  onSelectCollectionType = (title: SubjectTypeCn) => {
+    const collectionType = MODEL_SUBJECT_TYPE.getLabel<SubjectType>(title)
+    if (!collectionType || collectionType === this.state.collectionType) return
+
+    t('空间.收藏类型切换', {
+      userId: this.userId,
+      title
+    })
+
+    this.setState({
+      collectionType,
+      expand: {
+        ...DEFAULT_COLLECTION_EXPAND
+      }
+    })
+    this.fetchUserCollections()
   }
 
   /** 去用户的所有收藏页面 */

--- a/src/screens/user/zone/store/computed.ts
+++ b/src/screens/user/zone/store/computed.ts
@@ -22,9 +22,9 @@ import { fixedRemote } from '@utils/user-setting'
 import { IMG_EMPTY_DARK, TEXT_ONLY } from '@constants'
 import { H_HEADER, TABS, TABS_WITH_TINYGRAIL } from '../ds'
 import State from './state'
-import { EXCLUDE_STATE, NAMESPACE } from './ds'
+import { COLLECTION_STATUS_MAP, COLLECTION_STATUS_TEXT, EXCLUDE_STATE, NAMESPACE } from './ds'
 
-import type { ImageSource } from '@types'
+import type { CollectionStatusCn, ImageSource, SubjectTypeCn } from '@types'
 
 export default class Computed extends State {
   /** 本地化 */
@@ -72,22 +72,57 @@ export default class Computed extends State {
     return this.usersInfo.username
   }
 
-  /** 用户番剧收藏 */
+  /** 用户收藏概览 */
   @computed get userCollections() {
-    return userStore.userCollections(undefined, this.userId)
+    return userStore.userCollections(this.state.collectionType, this.userId)
   }
 
-  /** 用户番剧收藏 section list data */
+  /** 当前收藏类型中文 */
+  @computed get collectionTypeLabel() {
+    switch (this.state.collectionType) {
+      case 'book':
+        return '书籍' as SubjectTypeCn
+
+      case 'music':
+        return '音乐' as SubjectTypeCn
+
+      case 'game':
+        return '游戏' as SubjectTypeCn
+
+      case 'real':
+        return '三次元' as SubjectTypeCn
+
+      default:
+        return '动画' as SubjectTypeCn
+    }
+  }
+
+  /** 当前收藏状态文案 */
+  collectionStatusText(status: CollectionStatusCn) {
+    return COLLECTION_STATUS_TEXT[this.state.collectionType]?.[status] || status
+  }
+
+  /** 归一成通用收藏状态 */
+  collectionStatus(status: string): CollectionStatusCn {
+    return COLLECTION_STATUS_MAP[status] || (status as CollectionStatusCn)
+  }
+
+  /** 用户收藏概览 section list data */
   @computed get sections() {
-    return this.userCollections.list.map(item => ({
-      title: item.status,
-      count: item.count,
-      data: [
-        {
-          list: item.list
-        }
-      ]
-    }))
+    return this.userCollections.list.map(item => {
+      const status = this.collectionStatus(item.status)
+
+      return {
+        title: this.collectionStatusText(status),
+        status,
+        count: item.count,
+        data: [
+          {
+            list: item.list
+          }
+        ]
+      }
+    })
   }
 
   /** 用户时间胶囊 */

--- a/src/screens/user/zone/store/ds.ts
+++ b/src/screens/user/zone/store/ds.ts
@@ -6,21 +6,76 @@
  */
 import { INIT_USERS } from '@stores/users/init'
 import { TIMELINE_TYPE } from '@constants'
-import { COMPONENT } from '../ds'
+import { COLLECTION_TYPES, COMPONENT } from '../ds'
 
-import type { CompletionItem, Loaded, TimeLineType } from '@types'
+import type { CollectionStatusCn, CompletionItem, Loaded, SubjectType, TimeLineType } from '@types'
 
 export const NAMESPACE = `Screen${COMPONENT}` as const
 
-export const EXCLUDE_STATE = {
-  /** 番剧收藏状态折叠 */
-  expand: {
-    在看: true,
-    看过: false,
-    想看: false,
-    搁置: false,
-    抛弃: false
+export const DEFAULT_COLLECTION_TYPE = COLLECTION_TYPES[0].value
+
+export const DEFAULT_COLLECTION_EXPAND: Record<CollectionStatusCn, boolean> = {
+  在看: true,
+  看过: false,
+  想看: false,
+  搁置: false,
+  抛弃: false
+}
+
+export const COLLECTION_STATUS_TEXT: Record<
+  SubjectType,
+  Partial<Record<CollectionStatusCn, string>>
+> = {
+  anime: {
+    在看: '在看',
+    看过: '看过',
+    想看: '想看'
   },
+  book: {
+    在看: '在读',
+    看过: '读过',
+    想看: '想读'
+  },
+  music: {
+    在看: '在听',
+    看过: '听过',
+    想看: '想听'
+  },
+  game: {
+    在看: '在玩',
+    看过: '玩过',
+    想看: '想玩'
+  },
+  real: {
+    在看: '在看',
+    看过: '看过',
+    想看: '想看'
+  }
+}
+
+export const COLLECTION_STATUS_MAP: Record<string, CollectionStatusCn> = {
+  想看: '想看',
+  想读: '想看',
+  想听: '想看',
+  想玩: '想看',
+  看过: '看过',
+  读过: '看过',
+  听过: '看过',
+  玩过: '看过',
+  在看: '在看',
+  在读: '在看',
+  在听: '在看',
+  在玩: '在看',
+  搁置: '搁置',
+  抛弃: '抛弃'
+}
+
+export const EXCLUDE_STATE = {
+  /** 收藏状态折叠 */
+  expand: DEFAULT_COLLECTION_EXPAND,
+
+  /** 收藏类型 */
+  collectionType: DEFAULT_COLLECTION_TYPE,
 
   /** 是否显示历史头像模态框 */
   visible: false,

--- a/src/screens/user/zone/store/fetch.ts
+++ b/src/screens/user/zone/store/fetch.ts
@@ -47,9 +47,9 @@ export default class Fetch extends Computed {
     return usersStore.fetchUsers(this.userId)
   }
 
-  /** 用户番剧信息 */
+  /** 用户收藏概览 */
   fetchUserCollections = () => {
-    return userStore.fetchUserCollections('anime', this.userId)
+    return userStore.fetchUserCollections(this.state.collectionType, this.userId)
   }
 
   /** 用户时间胶囊 (60s) */


### PR DESCRIPTION
将用户空间页原“番剧”标签调整为“收藏”，并在标签标题旁复用“时间线”的 Popover 样式显示当前收藏类型。用户可在动画、书籍、音乐、游戏、三次元之间切换，页面按当前类型按需请求对应收藏概览。

- 新增用户空间收藏类型配置，默认展示动画
- 收藏标签选中时显示当前类型灰色小字，并提供类型切换菜单
- 切换类型时调用 userStore.fetchUserCollections(type, userId) 获取对应收藏概览
- 按收藏类型映射分组标题：
  - 动画 / 三次元：在看、看过、想看
  - 书籍：在读、读过、想读
  - 音乐：在听、听过、想听
  - 游戏：在玩、玩过、想玩
- 保留搁置、抛弃的通用状态文案
- 切换收藏类型时重置为当前类型的进行中分组展开
- 修正超展开列表注册滚动引用时错误依赖“番剧”标题的问题
- 增加“空间.收藏类型切换”埋点事件映射