### PR TITLE
- [空间] 修复用户时间线触底加载重复第一页的问题

### DIFF
--- a/src/stores/timeline/common.ts
+++ b/src/stores/timeline/common.ts
@@ -48,7 +48,7 @@ export async function fetchTimeline(
   const isSelf = scopeCn === '自己'
 
   const html = await fetchHTML({
-    url: HTML_TIMELINE(scope, type, userId || userInfo?.username, page)
+    url: HTML_TIMELINE(scope, type, userInfo?.username || userId, page)
   })
   const list = []
   const $ = cheerio(htmlMatch(html, '<div id="timeline">', '<div id="tmlPager">'))


### PR DESCRIPTION
用户空间时间线触底加载下一页时，分页页码会正常递增，但请求用户个人时间线时使用了数字 userId 作为 /user/{id} 路径参数。

Bangumi 网页端在 /user/{数字ID}/timeline?page=2&ajax=1 场景下会返回第一页内容，导致列表合并时反复追加第一页。

修复方式：

- 优先使用 userInfo.username 构造请求 URL
- username 缺失时保留原 userId fallback

Fixes #297