### PR TITLE
- [Android] debug 构建支持与 release 版本共存安装

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
-import com.android.build.OutputFile
-
 def expoVersionCode = "node -p require('../app.json').expo.android.versionCode".execute().text.trim().toInteger()
 def expoVersionName = "node -p require('../app.json').expo.version".execute().text.trim()
 
@@ -131,8 +129,9 @@ android {
 
   buildTypes {
     debug {
+      applicationIdSuffix ".dev"
       // signingConfig signingConfigs.debug
-      signingConfig signingConfigs.release
+      // signingConfig signingConfigs.release
     }
     release {
       // Caution! In production, you need to generate your own keystore file.


### PR DESCRIPTION
## 功能描述

现在安卓端 build.gradle 调试构建配置如下：

```
debug {
  // signingConfig signingConfigs.debug
  signingConfig signingConfigs.release
}
```

这有两个不方便的地方：

1. 只是想调试也要有 keystore
2. 调试构建与正式构建包名相同，无作者签名的情况下无法覆盖安装。即使能覆盖安装，测试版也不应该覆盖日常使用的正式版，以免出现损坏日常数据的情况

因此改成：

```
debug {
  applicationIdSuffix ".dev"
  // signingConfig signingConfigs.debug
  // signingConfig signingConfigs.release
}
```

顺便移除未使用且报错的 `import com.android.build.OutputFile`