### PR TITLE
- [工具] 移除非必要 sudo 权限

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "expo start",
     "dev:offline": "EXPO_USE_EXOTIC=0 expo start --offline",
     "postinstall": "patch-package",
-    "env": "sudo node ./packages/env.js",
+    "env": "node ./packages/env.js",
     "k": "sudo purge",
     "kj": "ps -ef | grep java | awk 'NR==1 {print $2}' | xargs kill -15",
     "kp": "lsof -i :8081 | awk 'NR>1 {print $2}' | xargs kill",

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -54,7 +54,7 @@
     "expo-linking": "5.0.2",
     "expo-screen-orientation": "~6.0.6",
     "expo-speech": "~11.3.0",
-    "expo-splash-screen": "~0.20.5",
+    "expo-splash-screen": "0.20.4",
     "expo-status-bar": "1.6.0",
     "expo-web-browser": "12.3.2",
     "hoist-non-react-statics": "2.5.0",

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -7,7 +7,7 @@
     "dev": "expo start",
     "dev:offline": "EXPO_USE_EXOTIC=0 expo start --offline",
     "postinstall": "patch-package",
-    "env": "sudo node ./packages/env.js",
+    "env": "node ./packages/env.js",
     "k": "sudo purge",
     "kj": "ps -ef | grep java | awk 'NR==1 {print $2}' | xargs kill -15",
     "kp": "lsof -i :8081 | awk 'NR>1 {print $2}' | xargs kill",


### PR DESCRIPTION
1. sudo 提权之后会读不到 nvm 管理的 node
2. build 的时候 expo-splash-screen 依赖冲突了，降了一级才成功