### PR TITLE
自动生成 `alt_store.json` 用于 altstore source

### DIFF
--- a/.github/scripts/generate-altstore.py
+++ b/.github/scripts/generate-altstore.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import urllib.request
+
+OWNER = "czy0729"
+REPO = "Bangumi"
+
+SOURCE_URL = f"https://raw.githubusercontent.com/{OWNER}/{REPO}/main/alt_store.json"
+
+ICON_URL = (
+    "https://raw.githubusercontent.com/"
+    "czy0729/Bangumi/master/src/assets/images/foreground.png"
+)
+
+APP = {
+    "name": "Bangumi",
+    "bundleIdentifier": "com.czy0729.bangumi",
+    "developerName": "czy0729",
+    "iconURL": ICON_URL,
+    "localizedDescription": "Bangumi for iOS",
+}
+
+
+def github_json(url):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "altstore-generator",
+    }
+
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(url, headers=headers)
+
+    with urllib.request.urlopen(req) as r:
+        return json.load(r)
+
+
+def download_text(url):
+    with urllib.request.urlopen(url) as r:
+        return r.read().decode("utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", required=True)
+
+    args = parser.parse_args()
+
+    tag = f"upstream-{args.version}"
+
+    release = github_json(
+        f"https://api.github.com/repos/{OWNER}/{REPO}/releases/tags/{tag}"
+    )
+
+    ipa = None
+    sha = None
+
+    for asset in release["assets"]:
+        name = asset["name"]
+
+        if name.endswith(".ipa"):
+            ipa = asset
+
+        elif name.endswith(".ipa.sha256"):
+            sha = asset
+
+    if ipa is None:
+        raise RuntimeError("IPA asset not found")
+
+    if sha is None:
+        raise RuntimeError("SHA256 asset not found")
+
+    sha256 = download_text(sha["browser_download_url"]).split()[0]
+
+    version_entry = {
+        "version": args.version,
+        "buildVersion": args.version,
+        "date": release["published_at"],
+        "downloadURL": ipa["browser_download_url"],
+        "size": ipa["size"],
+        "sha256": sha256,
+        "localizedDescription": (
+            release["body"] if release["body"] else f"Upstream {args.version}"
+        ),
+    }
+
+    # Load existing source if available
+    if os.path.exists(args.output):
+        with open(args.output, "r") as f:
+            source = json.load(f)
+
+        versions = source.get("apps", [{}])[0].get("versions", [])
+
+    else:
+        source = {
+            "name": "Bangumi",
+            "identifier": "com.czy0729.bangumi",
+            "sourceURL": SOURCE_URL,
+            "apps": [{**APP, "versions": []}],
+        }
+
+        versions = []
+
+    # Remove existing version if it already exists
+    versions = [v for v in versions if v.get("version") != args.version]
+
+    # Add new version
+    versions.append(version_entry)
+
+    # Sort newest first
+    versions.sort(key=lambda x: x.get("version", ""), reverse=True)
+
+    source["apps"][0]["versions"] = versions
+
+    with open(args.output, "w") as f:
+        json.dump(source, f, indent=2, ensure_ascii=False)
+
+    print(f"Generated {args.output} with {len(versions)} versions")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate-altstore.py
+++ b/.github/scripts/generate-altstore.py
@@ -81,7 +81,7 @@ def main():
 
     version_entry = {
         "version": args.version,
-        "buildVersion": args.version,
+        "buildVersion": 1,
         "date": release["published_at"],
         "downloadURL": ipa["browser_download_url"],
         "size": ipa["size"],

--- a/.github/scripts/generate-altstore.py
+++ b/.github/scripts/generate-altstore.py
@@ -17,7 +17,7 @@ ICON_URL = (
 
 APP = {
     "name": "Bangumi",
-    "bundleIdentifier": "com.czy0729.bangumi",
+    "bundleIdentifier": "tv.bangumi.czy0729",
     "developerName": "czy0729",
     "iconURL": ICON_URL,
     "localizedDescription": "Bangumi for iOS",
@@ -101,7 +101,7 @@ def main():
     else:
         source = {
             "name": "Bangumi",
-            "identifier": "com.czy0729.bangumi",
+            "identifier": "tv.bangumi.czy0729",
             "sourceURL": SOURCE_URL,
             "apps": [{**APP, "versions": []}],
         }

--- a/.github/workflows/update-altstore.yml
+++ b/.github/workflows/update-altstore.yml
@@ -1,0 +1,48 @@
+name: Update AltStore Source
+
+on:
+  push:
+    tags:
+      - 'upstream-*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          echo "version=${GITHUB_REF_NAME#upstream-}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate alt_store.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/generate-altstore.py \
+            --version "${{ steps.version.outputs.version }}" \
+            --output alt_store.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bot/update-${{ steps.version.outputs.version }}
+          delete-branch: true
+          commit-message: |
+            chore: update AltStore source ${{ steps.version.outputs.version }}
+          title: |
+            Update AltStore source (${{ steps.version.outputs.version }})
+          body: |
+            This PR was generated automatically from the upstream release.

--- a/alt_store.json
+++ b/alt_store.json
@@ -11,7 +11,7 @@
       "localizedDescription": "Bangumi for iOS",
       "versions": [
         {
-          "version": "8.36.5",
+          "version": "8.36.4",
           "buildVersion": "8.36.4",
           "date": "2026-07-05T11:10:11Z",
           "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.36.5/Bangumi-8.36.5-unsigned.ipa",

--- a/alt_store.json
+++ b/alt_store.json
@@ -1,11 +1,11 @@
 {
   "name": "Bangumi",
-  "identifier": "com.czy0729.bangumi",
+  "identifier": "tv.bangumi.czy0729",
   "sourceURL": "https://raw.githubusercontent.com/czy0729/Bangumi/main/alt_store.json",
   "apps": [
     {
       "name": "Bangumi",
-      "bundleIdentifier": "com.czy0729.bangumi",
+      "bundleIdentifier": "tv.bangumi.czy0729",
       "developerName": "czy0729",
       "iconURL": "https://raw.githubusercontent.com/czy0729/Bangumi/master/src/assets/images/foreground.png",
       "localizedDescription": "Bangumi for iOS",

--- a/alt_store.json
+++ b/alt_store.json
@@ -1,0 +1,34 @@
+{
+  "name": "Bangumi",
+  "identifier": "com.czy0729.bangumi",
+  "sourceURL": "https://raw.githubusercontent.com/czy0729/Bangumi/main/alt_store.json",
+  "apps": [
+    {
+      "name": "Bangumi",
+      "bundleIdentifier": "com.czy0729.bangumi",
+      "developerName": "czy0729",
+      "iconURL": "https://raw.githubusercontent.com/czy0729/Bangumi/master/src/assets/images/foreground.png",
+      "localizedDescription": "Bangumi for iOS",
+      "versions": [
+        {
+          "version": "8.36.5",
+          "buildVersion": "8.36.5",
+          "date": "2026-07-05T11:10:11Z",
+          "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.36.5/Bangumi-8.36.5-unsigned.ipa",
+          "size": 23060321,
+          "sha256": "55ae3223467d52b8980c6066e4e795befd35072c060a8453bea109e3639c53dc",
+          "localizedDescription": "Automated unsigned IPA build for upstream Bangumi tag `8.36.5`.\n\nSource: https://github.com/czy0729/Bangumi/tree/8.36.5\n\nSource archive: https://github.com/czy0729/Bangumi/archive/refs/tags/8.36.5.zip\n\nThe IPA is intentionally unsigned and should be signed by your sideloading tool or a later signing workflow.\n\nBuild run: https://github.com/czy0729/Bangumi/actions/runs/28738239886"
+        },
+        {
+          "version": "8.35.2",
+          "buildVersion": "8.35.2",
+          "date": "2026-06-23T16:46:29Z",
+          "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.35.2/Bangumi-8.35.2-unsigned.ipa",
+          "size": 23040371,
+          "sha256": "db9bc0e30e1b5dfbfd7bd723c06b84af960eca393e709a9b656063b1d5a5f292",
+          "localizedDescription": "Automated unsigned IPA build for upstream Bangumi tag `8.35.2`.\n\nSource: https://github.com/czy0729/Bangumi/tree/8.35.2\n\nSource archive: https://github.com/czy0729/Bangumi/archive/refs/tags/8.35.2.zip\n\nThe IPA is intentionally unsigned and should be signed by your sideloading tool or a later signing workflow.\n\nBuild run: https://github.com/czy0729/Bangumi/actions/runs/28040906264"
+        }
+      ]
+    }
+  ]
+}

--- a/alt_store.json
+++ b/alt_store.json
@@ -12,7 +12,7 @@
       "versions": [
         {
           "version": "8.36.5",
-          "buildVersion": "8.36.5",
+          "buildVersion": "8.36.4",
           "date": "2026-07-05T11:10:11Z",
           "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.36.5/Bangumi-8.36.5-unsigned.ipa",
           "size": 23060321,

--- a/alt_store.json
+++ b/alt_store.json
@@ -12,21 +12,12 @@
       "versions": [
         {
           "version": "8.36.4",
-          "buildVersion": "8.36.4",
+          "buildVersion": "1",
           "date": "2026-07-05T11:10:11Z",
           "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.36.5/Bangumi-8.36.5-unsigned.ipa",
           "size": 23060321,
           "sha256": "55ae3223467d52b8980c6066e4e795befd35072c060a8453bea109e3639c53dc",
           "localizedDescription": "Automated unsigned IPA build for upstream Bangumi tag `8.36.5`.\n\nSource: https://github.com/czy0729/Bangumi/tree/8.36.5\n\nSource archive: https://github.com/czy0729/Bangumi/archive/refs/tags/8.36.5.zip\n\nThe IPA is intentionally unsigned and should be signed by your sideloading tool or a later signing workflow.\n\nBuild run: https://github.com/czy0729/Bangumi/actions/runs/28738239886"
-        },
-        {
-          "version": "8.35.2",
-          "buildVersion": "8.35.2",
-          "date": "2026-06-23T16:46:29Z",
-          "downloadURL": "https://github.com/czy0729/Bangumi/releases/download/upstream-8.35.2/Bangumi-8.35.2-unsigned.ipa",
-          "size": 23040371,
-          "sha256": "db9bc0e30e1b5dfbfd7bd723c06b84af960eca393e709a9b656063b1d5a5f292",
-          "localizedDescription": "Automated unsigned IPA build for upstream Bangumi tag `8.35.2`.\n\nSource: https://github.com/czy0729/Bangumi/tree/8.35.2\n\nSource archive: https://github.com/czy0729/Bangumi/archive/refs/tags/8.35.2.zip\n\nThe IPA is intentionally unsigned and should be signed by your sideloading tool or a later signing workflow.\n\nBuild run: https://github.com/czy0729/Bangumi/actions/runs/28040906264"
         }
       ]
     }


### PR DESCRIPTION
效果：在 altstore 中添加对应的源之后即可直接安装，同时接受新的版本更新

<img width="480" height="1039" alt="image" src="https://github.com/user-attachments/assets/b5ce3810-9979-4491-ae53-ab82a2dc2804" />