### PR TITLE
fix: 修复 IPA workflow 的 worklets 打包失败

### DIFF
--- a/.github/workflows/build-upstream-ipa.yml
+++ b/.github/workflows/build-upstream-ipa.yml
@@ -168,6 +168,16 @@ jobs:
             'expo-file-system/legacy',
             'expo-file-system',
           )
+          replaceInFile(
+            'src/utils/worklets/index.ts',
+            "(require('react-native-worklets') as typeof import('react-native-worklets')).scheduleOnRN",
+            'reanimatedScheduleOnRN',
+          )
+          replaceInFile(
+            'src/utils/worklets/index.ts',
+            "(require('react-native-worklets') as typeof import('react-native-worklets')).scheduleOnUI",
+            'reanimatedScheduleOnUI',
+          )
 
           fs.appendFileSync(process.env.GITHUB_ENV, `APP_VERSION=${appVersion}\n`)
           NODE


### PR DESCRIPTION
## 问题

8.39.0 之后，IPA workflow 在 `Build Release app` 阶段打包 Metro bundle 时失败：

```text
Unable to resolve module react-native-worklets from src/utils/worklets/index.ts
```

`packages/ipa` 仍使用 Expo 52 / Reanimated 3，未安装 `react-native-worklets`。虽然 IPA 运行时会走 Reanimated fallback，但 Metro 会静态解析条件分支里的 `require('react-native-worklets')`，因此构建提前失败。

## 修改

在 IPA Prepare 阶段将 `scheduleOnRN` 和 `scheduleOnUI` 的 worklets 引用替换为现有 Reanimated fallback，只影响下载到 runner 的 IPA 构建源码，不改应用源码或其他平台。

## 验证

- YAML 解析及 Node 脚本语法检查通过
- 本地 `expo export --platform ios` 成功，7163 modules 完成 bundle
- fork 的 8.39.0 unsigned IPA workflow 完整通过，包括依赖、Pods、xcodebuild、IPA 校验与 Release 上传
- 成功 run：https://github.com/AvalonUltra/Bangumi/actions/runs/33000129695
- 产物：https://github.com/AvalonUltra/Bangumi/releases/tag/upstream-8.39.0